### PR TITLE
Downgrade indicatif and xwin

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,9 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.1"
+version = "0.17.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfddc9561e8baf264e0e45e197fd7696320026eb10a8180340debc27b18f535b"
+checksum = "2946516aa80379c1e6ee9cfa75a7b2faf23f63690f44d682e7fecd0141bbcaf2"
 dependencies = [
  "console",
  "number_prefix",
@@ -1305,9 +1305,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-normalization"
@@ -1361,9 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683f0a095f6dcf74520a5f17a12452ae6f970abbd2443299a1e226fd38195f2b"
+checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
 
 [[package]]
 name = "valuable"
@@ -1559,9 +1559,9 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "xwin"
-version = "0.2.8"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d800084cf7137e4a3e80587ff027d53943e05586a50a3655c2622e6700ba3f"
+checksum = "3f66ef70cc262a6da73cb13fae0c767add6bd0b85fa46053b263732fecfb9b9f"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ cargo-options = "0.4.0"
 clap = { version = "3.1.2", features = ["derive", "env", "wrap_help"] }
 dirs = "4.0.0"
 fs-err = "2.7.0"
-indicatif = "0.17.0"
+indicatif = "0.17.0-rc.6"
 path-slash = "0.2.0"
 which = "4.2.4"
-xwin = { version = "0.2.8", default-features = false }
+xwin = { version = "=0.2.5", default-features = false }
 
 [features]
 # By default we use rustls for TLS

--- a/src/common.rs
+++ b/src/common.rs
@@ -235,7 +235,7 @@ impl XWinOptions {
             .xwin_variant
             .iter()
             .fold(0, |acc, var| acc | *var as u32);
-        let pruned = xwin::prune_pkg_list(&pkg_manifest, arches, variants, false)?;
+        let pruned = xwin::prune_pkg_list(&pkg_manifest, arches, variants)?;
         let op = xwin::Ops::Splat(xwin::SplatConfig {
             include_debug_libs: false,
             include_debug_symbols: false,
@@ -252,18 +252,11 @@ impl XWinOptions {
         .map(|pay| {
             let prefix = match pay.kind {
                 xwin::PayloadKind::CrtHeaders => "CRT.headers".to_owned(),
-                xwin::PayloadKind::AtlHeaders => "ATL.headers".to_owned(),
                 xwin::PayloadKind::CrtLibs => {
                     format!(
                         "CRT.libs.{}.{}",
                         pay.target_arch.map(|ta| ta.as_str()).unwrap_or("all"),
                         pay.variant.map(|v| v.as_str()).unwrap_or("none")
-                    )
-                }
-                xwin::PayloadKind::AtlLibs => {
-                    format!(
-                        "ATL.libs.{}",
-                        pay.target_arch.map(|ta| ta.as_str()).unwrap_or("all"),
                     )
                 }
                 xwin::PayloadKind::SdkHeaders => {
@@ -284,7 +277,7 @@ impl XWinOptions {
             };
 
             let pb = mp.add(
-                ProgressBar::with_draw_target(Some(0), draw_target.into()).with_prefix(prefix).with_style(
+                ProgressBar::with_draw_target(0, draw_target.into()).with_prefix(prefix).with_style(
                     ProgressStyle::default_bar()
                         .template("{spinner:.green} {prefix:.bold} [{elapsed}] {wide_bar:.green} {bytes}/{total_bytes} {msg}").unwrap()
                         .progress_chars("=> "),
@@ -323,7 +316,7 @@ impl XWinOptions {
         ctx: &xwin::Ctx,
         dt: ProgressTarget,
     ) -> Result<xwin::manifest::PackageManifest> {
-        let manifest_pb = ProgressBar::with_draw_target(Some(0), dt.into())
+        let manifest_pb = ProgressBar::with_draw_target(0, dt.into())
             .with_style(
             ProgressStyle::default_bar()
                 .template(


### PR DESCRIPTION
Fix build on some 32-bit platforms caused by https://github.com/console-rs/indicatif/issues/475

* Reverts 377aa7560b207dd6532475352bc790df70e23ad3
* Reverts 310463f1b3340124db36a224316b402ac05cca2e