### PR TITLE
Upgrade to clap 4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,11 +99,11 @@ checksum = "88ad0e1e3e88dd237a156ab9f571021b8a158caa0ae44b1968a241efb5144c1e"
 
 [[package]]
 name = "cargo-options"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e154133a9bd3d46ad7e4be70b0c5915b62c1ddb57d4f31633146976fbdabe3d"
+checksum = "6755badfe5e0224c6e2ae710d82cd7dce5866e8ebcb22e5f3eced8f25fbd1ace"
 dependencies = [
- "clap",
+ "clap 4.0.15",
 ]
 
 [[package]]
@@ -112,7 +112,7 @@ version = "0.11.0"
 dependencies = [
  "anyhow",
  "cargo-options",
- "clap",
+ "clap 4.0.15",
  "dirs",
  "fs-err",
  "indicatif",
@@ -158,14 +158,30 @@ checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.18",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
  "terminal_size 0.2.1",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf8832993da70a4c6d13c581f4463c2bdda27b9bf1c5498dc4365543abe6d6f"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive 4.0.13",
+ "clap_lex 0.3.0",
+ "once_cell",
+ "strsim",
+ "termcolor",
+ "terminal_size 0.2.1",
 ]
 
 [[package]]
@@ -182,10 +198,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -594,9 +632,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1106,9 +1144,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
 dependencies = [
  "itoa",
  "ryu",
@@ -1624,7 +1662,7 @@ dependencies = [
  "bytes",
  "cab",
  "camino",
- "clap",
+ "clap 3.2.22",
  "cli-table",
  "flate2",
  "indicatif",
@@ -1646,9 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf225bcf73bb52cbb496e70475c7bd7a3f769df699c0020f6c7bd9a96dcf0b8d"
+checksum = "537ce7411d25e54e8ae21a7ce0b15840e7bfcff15b51d697ec3266cc76bdf080"
 dependencies = [
  "byteorder",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/messense/cargo-xwin"
 
 [dependencies]
 anyhow = "1.0.53"
-cargo-options = "0.4.0"
-clap = { version = "3.1.2", features = ["derive", "env", "wrap_help"] }
+cargo-options = "0.5.2"
+clap = { version = "4.0.0", features = ["derive", "env", "wrap_help"] }
 dirs = "4.0.0"
 fs-err = "2.7.0"
 indicatif = "0.17.0-rc.6"

--- a/src/bin/cargo-xwin.rs
+++ b/src/bin/cargo-xwin.rs
@@ -4,28 +4,28 @@ use cargo_xwin::{Build, Run, Rustc, Test};
 use clap::{Parser, Subcommand};
 
 #[derive(Debug, Parser)]
-#[clap(version, name = "cargo-xwin")]
+#[command(version, name = "cargo-xwin")]
 pub enum Cli {
-    #[clap(subcommand, name = "xwin")]
+    #[command(subcommand, name = "xwin")]
     Opt(Opt),
     // flatten opt here so that `cargo-xwin build` also works
-    #[clap(flatten)]
+    #[command(flatten)]
     Cargo(Opt),
 }
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Subcommand)]
-#[clap(version, global_setting(clap::AppSettings::DeriveDisplayOrder))]
+#[command(version, display_order = 1)]
 pub enum Opt {
-    #[clap(name = "build", alias = "b")]
+    #[command(name = "build", alias = "b")]
     Build(Build),
-    #[clap(name = "metadata")]
+    #[command(name = "metadata")]
     Metadata(Metadata),
-    #[clap(name = "run", alias = "r")]
+    #[command(name = "run", alias = "r")]
     Run(Run),
-    #[clap(name = "rustc")]
+    #[command(name = "rustc")]
     Rustc(Rustc),
-    #[clap(name = "test", alias = "t")]
+    #[command(name = "test", alias = "t")]
     Test(Test),
 }
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -9,12 +9,15 @@ use crate::common::XWinOptions;
 
 /// Compile a local package and all of its dependencies
 #[derive(Clone, Debug, Default, Parser)]
-#[clap(setting = clap::AppSettings::DeriveDisplayOrder, after_help = "Run `cargo help build` for more detailed information.")]
+#[command(
+    display_order = 1,
+    after_help = "Run `cargo help build` for more detailed information."
+)]
 pub struct Build {
-    #[clap(flatten)]
+    #[command(flatten)]
     pub cargo: cargo_options::Build,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub xwin: XWinOptions,
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -19,28 +19,28 @@ use xwin::util::ProgressTarget;
 #[derive(Clone, Debug, Parser)]
 pub struct XWinOptions {
     /// xwin cache directory
-    #[clap(long, value_parser, env = "XWIN_CACHE_DIR", hide = true)]
+    #[arg(long, env = "XWIN_CACHE_DIR", hide = true)]
     pub xwin_cache_dir: Option<PathBuf>,
 
     /// The architectures to include in CRT/SDK
-    #[clap(
+    #[arg(
         long,
         env = "XWIN_ARCH",
         value_parser = PossibleValuesParser::new(["x86", "x86_64", "aarch", "aarch64"])
             .map(|s| s.parse::<xwin::Arch>().unwrap()),
-        use_value_delimiter = true,
+        value_delimiter = ',',
         default_values_t = vec![xwin::Arch::X86_64, xwin::Arch::Aarch64],
         hide = true,
     )]
     pub xwin_arch: Vec<xwin::Arch>,
 
     /// The variants to include
-    #[clap(
+    #[arg(
         long,
         env = "XWIN_VARIANT",
         value_parser = PossibleValuesParser::new(["desktop", "onecore", /*"store",*/ "spectre"])
             .map(|s| s.parse::<xwin::Variant>().unwrap()),
-        use_value_delimiter = true,
+        value_delimiter = ',',
         default_values_t = vec![xwin::Variant::Desktop],
         hide = true,
     )]
@@ -48,7 +48,7 @@ pub struct XWinOptions {
 
     /// The version to retrieve, can either be a major version of 15 or 16, or
     /// a "<major>.<minor>" version.
-    #[clap(long, env = "XWIN_VERSION", default_value = "16", hide = true)]
+    #[arg(long, env = "XWIN_VERSION", default_value = "16", hide = true)]
     pub xwin_version: String,
 }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -10,16 +10,15 @@ use crate::common::XWinOptions;
 
 /// Run a binary or example of the local package
 #[derive(Clone, Debug, Default, Parser)]
-#[clap(
-    setting = clap::AppSettings::DeriveDisplayOrder,
-    trailing_var_arg = true,
-    after_help = "Run `cargo help run` for more detailed information.")
-]
+#[command(
+    display_order = 1,
+    after_help = "Run `cargo help run` for more detailed information."
+)]
 pub struct Run {
-    #[clap(flatten)]
+    #[command(flatten)]
     pub xwin: XWinOptions,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub cargo: cargo_options::Run,
 }
 

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -9,16 +9,15 @@ use crate::common::XWinOptions;
 
 /// Compile a package, and pass extra options to the compiler
 #[derive(Clone, Debug, Default, Parser)]
-#[clap(
-    setting = clap::AppSettings::DeriveDisplayOrder,
-    trailing_var_arg = true,
+#[command(
+    display_order = 1,
     after_help = "Run `cargo help rustc` for more detailed information."
 )]
 pub struct Rustc {
-    #[clap(flatten)]
+    #[command(flatten)]
     pub xwin: XWinOptions,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub cargo: cargo_options::Rustc,
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -10,16 +10,15 @@ use crate::common::XWinOptions;
 
 /// Execute all unit and integration tests and build examples of a local package
 #[derive(Clone, Debug, Default, Parser)]
-#[clap(
-    setting = clap::AppSettings::DeriveDisplayOrder,
-    trailing_var_arg = true,
-    after_help = "Run `cargo help test` for more detailed information.\nRun `cargo test -- --help` for test binary options.")
-]
+#[command(
+    display_order = 1,
+    after_help = "Run `cargo help test` for more detailed information.\nRun `cargo test -- --help` for test binary options."
+)]
 pub struct Test {
-    #[clap(flatten)]
+    #[command(flatten)]
     pub xwin: XWinOptions,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub cargo: cargo_options::Test,
 }
 


### PR DESCRIPTION
`xwin` still dependes on clap 3.0 but that's fine
because it's only for the `xwin` binary not the library