### PR TITLE
Fix bindgen being unable to find include directories (fixes #32)

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -160,6 +160,14 @@ impl XWinOptions {
                 cmd.env(format!("CFLAGS_{}", env_target), &cl_flags);
                 cmd.env(format!("CXXFLAGS_{}", env_target), &cl_flags);
 
+                cmd.env(
+                    format!("BINDGEN_EXTRA_CLANG_ARGS_{}", env_target), 
+                    format!(
+                        "-I{dir}/crt/include -I{dir}/sdk/include/ucrt -I{dir}/sdk/include/um -I{dir}/sdk/include/shared",
+                        dir = xwin_cache_dir.display()
+                    )
+                );
+
                 let target_arch = target
                     .split_once('-')
                     .map(|(x, _)| x)


### PR DESCRIPTION
This pull request adds BINDGEN_EXTRA_CLANG_ARGS to the environment variables list so that bindgen can find the proper include directories.

Closes #32 